### PR TITLE
The source link needs to be in an object tag

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -15,7 +15,14 @@ thumbnail <- function(title, img, href, caption = TRUE, source = NULL) {
         htmltools::div(class = ifelse(caption, "caption", ""),
             ifelse(caption, title, ""),
             if (caption && !is.null(source)) {
-              htmltools::a(class = "source", href = source, "(Source)")
+              htmltools::tags$object(
+                htmltools::span(
+                  style = "float:right;",
+                  "(",
+                  htmltools::a(class = "source-repo", href = source, "Source"),
+                  ")"
+                )
+              )
             }
         )
       )
@@ -102,7 +109,7 @@ examples <- function(yml = "examples.yml", caption = TRUE, showcaseOnly = FALSE,
     list(title = r["title"],
          img = r["img"],
          href = r["href"],
-         source = if(is.na(r["source"])) NULL else r["source"]
+         source = if (is.na(r["source"])) NULL else r["source"]
     )
   })
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,12 +16,7 @@ thumbnail <- function(title, img, href, caption = TRUE, source = NULL) {
             ifelse(caption, title, ""),
             if (caption && !is.null(source)) {
               htmltools::tags$object(
-                htmltools::span(
-                  style = "float:right;",
-                  "(",
-                  htmltools::a(class = "source-repo", href = source, "Source"),
-                  ")"
-                )
+                htmltools::a(class = "source-repo", href = source, "(Source)")
               )
             }
         )
@@ -36,7 +31,7 @@ thumbnail <- function(title, img, href, caption = TRUE, source = NULL) {
 #' @export
 thumbnails <- function(thumbs) {
 
-  # capture arguments and setup rows to return
+  #living since capture arguments and setup rows to return
   numThumbs <- length(thumbs)
   fullRows <- numThumbs / 3
   rows <- htmltools::tagList()

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -32,7 +32,13 @@
           <img src="path/to/img"/>
           <div class="caption">
             title
-            <a class="source" href="repo.org/source">(Source)</a>
+            <object>
+              <span style="float:right;">
+                (
+                <a class="source-repo" href="repo.org/source">Source</a>
+                )
+              </span>
+            </object>
           </div>
         </a>
       </div>
@@ -106,7 +112,13 @@
             <img src="path/to/img"/>
             <div class="caption">
               title
-              <a class="source" href="repo.org/source">(Source)</a>
+              <object>
+                <span style="float:right;">
+                  (
+                  <a class="source-repo" href="repo.org/source">Source</a>
+                  )
+                </span>
+              </object>
             </div>
           </a>
         </div>
@@ -135,7 +147,13 @@
             <img src="path/to/img"/>
             <div class="caption">
               title
-              <a class="source" href="repo.org/source">(Source)</a>
+              <object>
+                <span style="float:right;">
+                  (
+                  <a class="source-repo" href="repo.org/source">Source</a>
+                  )
+                </span>
+              </object>
             </div>
           </a>
         </div>

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -33,11 +33,7 @@
           <div class="caption">
             title
             <object>
-              <span style="float:right;">
-                (
-                <a class="source-repo" href="repo.org/source">Source</a>
-                )
-              </span>
+              <a class="source-repo" href="repo.org/source">(Source)</a>
             </object>
           </div>
         </a>
@@ -113,11 +109,7 @@
             <div class="caption">
               title
               <object>
-                <span style="float:right;">
-                  (
-                  <a class="source-repo" href="repo.org/source">Source</a>
-                  )
-                </span>
+                <a class="source-repo" href="repo.org/source">(Source)</a>
               </object>
             </div>
           </a>
@@ -148,11 +140,7 @@
             <div class="caption">
               title
               <object>
-                <span style="float:right;">
-                  (
-                  <a class="source-repo" href="repo.org/source">Source</a>
-                  )
-                </span>
+                <a class="source-repo" href="repo.org/source">(Source)</a>
               </object>
             </div>
           </a>


### PR DESCRIPTION
We get the trick to use `<object>` from https://github.com/rstudio/learnr/commit/a2f98790423b5a96d8468aba025273f977fe5716 

Example: https://eager-davinci-ea43cc.netlify.app/articles/articles/examples.html