### PR TITLE
fix: Home redirect with hash or query params

### DIFF
--- a/inst/pkgdown/templates/in-header-home.html
+++ b/inst/pkgdown/templates/in-header-home.html
@@ -1,6 +1,8 @@
 <!-- from quillt: JS redirect for homepage -->
 <script>
-  if (!/(\/|html?)$/.test(window.location.href)){
-    window.location.replace(window.location.href + '/');
+  if (!/(\/|html?)$/.test(window.location.pathname)) {
+    const newHome = new URL(window.location.href);
+    newHome.pathname = newHome.pathname + '/';
+    window.location.replace(newHome.toString())
   }
 </script>


### PR DESCRIPTION
Fixes https://github.com/rstudio/thematic/issues/154

The homepage redirect that adds the trailing slash as needed – e.g. `rstudio.github.io/thematic` → `rstudio.github.io/thematic/` – wasn't taking into account the url hash or query parameters.